### PR TITLE
Modernize wheel build CI, update cibuildwheel configs and packaging deps

### DIFF
--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -1,31 +1,115 @@
 name: Build Python wheels (cibuildwheel)
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }} / ${{ matrix.config }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.config }} / ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-15]
-        config: [cibuildwheel, cibuildwheel-tensorflow]
+        include:
+          - runner: ubuntu-latest
+            os: linux
+            arch: x86_64
+            config: cibuildwheel
+            cibw_platform: linux
+          - runner: ubuntu-latest
+            os: linux
+            arch: x86_64
+            config: cibuildwheel-tensorflow
+            cibw_platform: linux
+          - runner: ubuntu-24.04-arm
+            os: linux
+            arch: arm64
+            config: cibuildwheel
+            skip_reason: ARM Linux wheel builds are temporarily disabled until the aarch64 manylinux dependency bootstrap is stabilized.
+          - runner: ubuntu-24.04-arm
+            os: linux
+            arch: arm64
+            config: cibuildwheel-tensorflow
+            skip_reason: essentia-tensorflow wheels are currently limited to Linux x86_64 and macOS due TensorFlow binary/toolchain constraints.
+          - runner: windows-latest
+            os: windows
+            arch: x86_64
+            config: cibuildwheel
+            cibw_platform: windows
+          - runner: windows-latest
+            os: windows
+            arch: x86_64
+            config: cibuildwheel-tensorflow
+            skip_reason: TensorFlow wheel build pipeline is not supported on Windows in this repository.
+          - runner: windows-11-arm
+            os: windows
+            arch: arm64
+            config: cibuildwheel
+            cibw_platform: windows
+          - runner: windows-11-arm
+            os: windows
+            arch: arm64
+            config: cibuildwheel-tensorflow
+            skip_reason: TensorFlow wheel build pipeline is not supported on Windows in this repository.
+          - runner: macos-15-intel
+            os: macos
+            arch: x86_64
+            config: cibuildwheel
+            cibw_platform: macos
+          - runner: macos-15-intel
+            os: macos
+            arch: x86_64
+            config: cibuildwheel-tensorflow
+            cibw_platform: macos
+          - runner: macos-latest
+            os: macos
+            arch: arm64
+            config: cibuildwheel
+            cibw_platform: macos
+          - runner: macos-latest
+            os: macos
+            arch: arm64
+            config: cibuildwheel-tensorflow
+            cibw_platform: macos
+
+    env:
+      CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+      CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
+      CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+      CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Fetch release tags from GitHub
-        # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+      - uses: actions/setup-python@v6
         with:
-          config-file: ${{ matrix.config }}.toml
+          python-version: "3.12"
 
-      - uses: actions/upload-artifact@v4
+      - name: Install cibuildwheel
+        if: ${{ !matrix.skip_reason }}
+        run: python -m pip install --upgrade pip "cibuildwheel==3.4.0"
+
+      - name: Build wheels
+        if: ${{ !matrix.skip_reason }}
+        run: python -m cibuildwheel --config-file "${{ matrix.config }}.toml" --platform "${{ matrix.cibw_platform }}" --output-dir wheelhouse
+
+      - name: Skip unsupported combination
+        if: ${{ matrix.skip_reason }}
+        run: |
+          echo "Skipping ${{ matrix.config }} on ${{ matrix.runner }}: ${{ matrix.skip_reason }}"
+
+      - uses: actions/upload-artifact@v6
+        if: ${{ !matrix.skip_reason }}
         with:
           path: ./wheelhouse/*.whl
-          name: artifact-${{ matrix.os }}-${{ matrix.config }}
+          name: wheels-${{ matrix.config }}-${{ matrix.os }}-${{ matrix.arch }}
+          if-no-files-found: error

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,16 +1,17 @@
-name: Build Python wheels
+name: Build Python wheels (legacy Docker)
+
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         WHEEL_TYPE:
           - i686
@@ -27,33 +28,32 @@ jobs:
             WITH_TENSORFLOW: 1
 
     env:
-      DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }} 
+      DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
       WITH_TENSORFLOW: ${{ matrix.WITH_TENSORFLOW }}
       PRE_CMD: ${{ matrix.PRE_CMD }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch release tags from GitHub
-        # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: "3.12"
       - name: Build wheels in a Docker image
         run: |
-          docker pull $DOCKER_IMAGE > /dev/null
-          docker run --rm -v `pwd`:/io --env WITH_TENSORFLOW=$WITH_TENSORFLOW $DOCKER_IMAGE $PRE_CMD /io/travis/build_wheels.sh
+          docker pull "$DOCKER_IMAGE" > /dev/null
+          docker run --rm -v "$(pwd):/io" --env WITH_TENSORFLOW="$WITH_TENSORFLOW" "$DOCKER_IMAGE" $PRE_CMD /io/travis/build_wheels.sh
       - name: Build sdist
-        run: | 
+        run: |
           ls wheelhouse/
-          sudo python setup.py sdist
+          python setup.py sdist
       - name: Upload wheels and sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
-          name: essentia-python-wheels
+          name: essentia-python-wheels-legacy-${{ matrix.WHEEL_TYPE }}
           path: |
             wheelhouse/essentia*.whl
             wheelhouse/essentia*.tar.gz

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -1,103 +1,47 @@
-[tool.cibuildwheel.linux]
-
-manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
-
-# Only support x86_64 for essentia-tensorflow.
-build = "cp**-manylinux_x86_64"
-
+[tool.cibuildwheel]
 skip = ["pp*", "*-musllinux*", "*i686", "*cp36*", "*cp37*", "*cp38*"]
-
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
-
-before-all = [
-  "PYBIN=/opt/python/cp36-cp36m/bin/",
-  "\"${PYBIN}/python\" waf configure --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
-  "\"${PYBIN}/python\" waf",
-  "\"${PYBIN}/python\" waf install",
-  # Monkey-patch package name.
-  # We could have a separate pyproject.toml configuration, but the build backend does not accept custom configuration filepaths.
-  "sed 's/^name *= *\"essentia\"$/name = \"essentia-tensorflow\"/' pyproject.toml > pyproject.toml.patched && mv pyproject.toml.patched pyproject.toml"
-]
-
 test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter, TensorflowPredict'"
 
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
+
+# TensorFlow wheels in this repository are currently distributed only for Linux x86_64.
+build = "cp**-manylinux_x86_64"
+before-all = [
+  "PYBIN=$(ls -d /opt/python/cp3*-cp3*/bin | head -n 1) && \"${PYBIN}/python\" waf configure --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\" && \"${PYBIN}/python\" waf && \"${PYBIN}/python\" waf install && sed 's/^name *= *\"essentia\"$/name = \"essentia-tensorflow\"/' pyproject.toml > pyproject.toml.patched && mv pyproject.toml.patched pyproject.toml"
+]
 
 [tool.cibuildwheel.macos]
-
-skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
-
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, MACOSX_DEPLOYMENT_TARGET=14.2 }
-
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
   "brew install chromaprint",
   "brew link --overwrite ffmpeg@2.8",
-  # Delocate checks for the min OS version (LC_BUILD_VERSION or C_VERSION_MIN_MACOSX).
-  # Tensorflow bottle a has minimum target of 14.2 which is too new.
-  # We could build from source as a workaround, however, it takes too much time on the CI worker.
-  # To keep it simple, just use the bottles available for tensorflow.
   "brew install tensorflow",
-  # ---
-  # Building tensorflow from source:
-  #"echo Checking available SDKs:",
-  #"xcodebuild -showsdks",
-  #"SDKROOT=$(xcrun --sdk macosx13.0 --show-sdk-path) brew install --build-from-source tensorflow",
-  # ---
-  # Override VIRTUAL_ENV set by cibuildwheel to ensure global install
   "VIRTUAL_ENV=/usr/local python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
   "python waf",
   "python waf install",
-  # Monkey-patch package name.
-  # We could have a separate pyproject.toml configuration, but the build backend does not accept custom configuration filepaths.
   "sed 's/^name *= *\"essentia\"$/name = \"essentia-tensorflow\"/' pyproject.toml > pyproject.toml.patched && mv pyproject.toml.patched pyproject.toml"
 ]
 
-# FIXME Temporarily disable testing on macos-13 runner. The wheel is tagged as macosx_14_2 due to the Tensorflow dependency, so it can't be installed by pip ("not a supported wheel on this platform").
-#test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter, TensorflowPredict'"
-
-
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
-
-skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
-
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1, MACOSX_DEPLOYMENT_TARGET=15.2 }
-
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
   "brew install chromaprint",
   "brew link --overwrite ffmpeg@2.8",
-  # Delocate checks for the min OS version (LC_BUILD_VERSION or C_VERSION_MIN_MACOSX).
-  # Tensorflow bottle a has minimum target of 15.2 which is too new.
-  # We could build from source as a workaround, however, it takes too much time on the CI worker.
-  # To keep it simple, just use the bottles available for tensorflow.
   "brew install tensorflow",
-  # ---
-  # Building tensorflow from source:
-  #"echo Checking available SDKs:",
-  #"xcodebuild -showsdks",
-  #"SDKROOT=$(xcrun --sdk macosx14.0 --show-sdk-path) brew install --build-from-source tensorflow",
-  # ---
-  # Override VIRTUAL_ENV set by cibuildwheel to ensure global install
   "VIRTUAL_ENV=/usr/local python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
   "sudo python waf install",
-  # Monkey-patch package name.
-  # We could have a separate pyproject.toml configuration, but the build backend does not accept custom configuration filepaths.
   "sed 's/^name *= *\"essentia\"$/name = \"essentia-tensorflow\"/' pyproject.toml > pyproject.toml.patched && mv pyproject.toml.patched pyproject.toml"
 ]
-
-# On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and
-# libavutil.54.31.100, depend on libSDL1.2-compat, which is a compatibility
-# layer for SDL2. libSDL1.2-compat expects SDL2 to be installed in the default
-# brew location (i.e., /opt/homebrew/opt/sdl2/lib), so the user would need to
-# install it via brew manually. Alternativelly, we can manualy copy the SDL2
-# libs into the wheel. This is a temporary solution, and in the long term we
-# should move to FFmpeg > 2.X.
 repair-wheel-command = [
   "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
   "mkdir -p {dest_dir}/essentia/.dylibs",

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -1,71 +1,46 @@
 [tool.cibuildwheel]
+skip = ["pp*", "*-musllinux*", "*i686", "*cp36*", "*cp37*", "*cp38*"]
+environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
+test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
-manylinux-i686-image = "mtgupf/essentia-builds:manylinux2014_i686"
-
-skip = ["pp*", "*-musllinux*", "*i686", "*cp36*", "*cp37*", "*cp38*"]
-
-environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
-
+manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"
 before-all = [
-  "PYBIN=/opt/python/cp36-cp36m/bin/",
-  "\"${PYBIN}/python\" waf configure --with-gaia --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
-  "\"${PYBIN}/python\" waf",
-  "\"${PYBIN}/python\" waf install"
+  "PYBIN=$(ls -d /opt/python/cp3*-cp3*/bin | head -n 1) && \"${PYBIN}/python\" waf configure --with-gaia --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\" && \"${PYBIN}/python\" waf && \"${PYBIN}/python\" waf install"
 ]
 
-test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"
-
+[tool.cibuildwheel.windows]
+before-build = [
+  "python -m pip install --upgrade pip"
+]
 
 [tool.cibuildwheel.macos]
-
-skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
-
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, MACOSX_DEPLOYMENT_TARGET=13.0 }
-
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
   "brew install chromaprint",
   "brew link --overwrite ffmpeg@2.8",
-  #"brew tap MTG/essentia",
-  #"brew install gaia --HEAD",
-  # Override VIRTUAL_ENV set by cibuildwheel to ensure global install
   "VIRTUAL_ENV=/usr/local python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
   "python waf",
   "python waf install"
 ]
 
-test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"
-
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
-
-skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
-
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1, MACOSX_DEPLOYMENT_TARGET=15.0 }
-
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
   "brew install chromaprint",
   "brew link --overwrite ffmpeg@2.8",
-  # Override VIRTUAL_ENV set by cibuildwheel to ensure global install
   "VIRTUAL_ENV=/usr/local python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
-  "sudo python waf install",
+  "sudo python waf install"
 ]
-
-# On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and
-# libavutil.54.31.100, depend on libSDL1.2-compat, which is a compatibility
-# layer for SDL2. libSDL1.2-compat expects SDL2 to be installed in the default
-# brew location (i.e., /opt/homebrew/opt/sdl2/lib), so the user would need to
-# install it via brew manually. Alternativelly, we can manualy copy the SDL2
-# libs into the wheel. This is a temporary solution, and in the long term we
-# should move to FFmpeg > 2.X.
 repair-wheel-command = [
   "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
   "mkdir -p {dest_dir}/essentia/.dylibs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "wheel >= 0.29.0",
-    "setuptools >= 48",
-    "numpy>=2.0.0rc1",
+    "wheel >= 0.45.1",
+    "setuptools >= 69.5.1",
+    "numpy>=2.0.0",
     "six",
 ]
 build-backend = "setuptools.build_meta"
@@ -13,6 +13,6 @@ license = "AGPL-3.0-only"
 dynamic = ["version", "description", "readme", "authors", "keywords", "classifiers", "urls"]
 dependencies = [
     "numpy>=1.25",
-    "pyyaml",
+    "pyyaml>=6.0.2",
     "six",
 ]

--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,14 @@ class EssentiaInstall(install_lib):
         global library
         install_dir = os.path.join(self.install_dir, library.split(os.sep)[-1])
         res = shutil.move(library, install_dir)
-        os.system("ls -l %s" % self.install_dir)
         return [install_dir]
 
 
 class EssentiaBuildExtension(build_ext):
     def run(self):
         global library
-        os.system('rm -rf tmp; mkdir tmp')
+        shutil.rmtree('tmp', ignore_errors=True)
+        os.makedirs('tmp', exist_ok=True)
 
         # Ugly hack using an enviroment variable... There's no way to pass a
         # custom flag to python setup.py bdist_wheel


### PR DESCRIPTION
### Motivation
- Modernize and unify the wheel build CI to support multiple runners, architectures and clearer skip logic for unsupported combinations.
- Move to newer GitHub Actions and tool versions to improve reproducibility and compatibility with current Python toolchain.
- Simplify and harden `cibuildwheel` configuration for both regular and TensorFlow-enabled wheels.

### Description
- Reworked `.github/workflows/build-wheels-cibuildwheel.yml` to an explicit `matrix.include` of runners/archs, added `skip_reason` handling, set `CIBW_*` env vars, switched to `actions/checkout@v6`, `actions/setup-python@v6`, install `cibuildwheel` via `pip`, and run `python -m cibuildwheel` with explicit `--platform` and output directory; artifact upload and naming were updated and unsupported combinations are skipped with logging.
- Updated legacy CI workflow `.github/workflows/build-wheels.yml` to only run on `workflow_dispatch`, upgraded actions to `@v6`, changed `python-version` to `3.12`, improved Docker invocation quoting, removed `sudo` for `sdist` creation, and updated artifact naming.
- Consolidated and simplified `cibuildwheel-tensorflow.toml` and `cibuildwheel.toml` by centralizing `tool.cibuildwheel` settings, updating skip lists, adding `manylinux-aarch64` image, consolidating `before-all` shell commands to robust shell sequences, setting `test-command`, and adding a Windows `before-build` step to upgrade `pip`.
- Bumped packaging build requirements in `pyproject.toml` (`wheel`, `setuptools`, `numpy`, `pyyaml` version constraints) and adjusted runtime `dependencies` minimums.
- Hardened `setup.py` temporary directory handling by replacing `rm -rf`/`mkdir` `os.system` calls with `shutil.rmtree(..., ignore_errors=True)` and `os.makedirs(..., exist_ok=True)`, and removed extraneous `ls` output.

### Testing
- No automated CI workflows were executed as part of this change in this PR; no automated test results are available from this rollout.
- The updated `cibuildwheel` configurations include `test-command` entries and the workflows are structured to run on GitHub Actions matrix runners when triggered, which will validate wheel builds when the workflows are executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c32c5deb9483329620f11eb3e987a4)