### PR TITLE
CI: add macOS runners, remove ffmpeg@2.8 linking, and simplify delocate repair

### DIFF
--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -7,9 +7,11 @@ jobs:
     name: Build wheels on ${{ matrix.os }} / ${{ matrix.config }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        # Build only on Ubuntu as requested.
-        os: [ubuntu-latest]
+        # Build wheels on Linux and macOS to keep both cibuildwheel
+        # configuration paths validated in CI.
+        os: [ubuntu-latest, macos-13, macos-14]
         config: [cibuildwheel, cibuildwheel-tensorflow]
 
     steps:

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -30,10 +30,8 @@ environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PRO
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
-  "brew link --force ffmpeg@2.8",
+  "brew install eigen libyaml fftw ffmpeg libsamplerate libtag",
   "brew install chromaprint",
-  "brew link --overwrite ffmpeg@2.8",
   # Delocate checks for the min OS version (LC_BUILD_VERSION or C_VERSION_MIN_MACOSX).
   # Tensorflow bottle a has minimum target of 14.2 which is too new.
   # We could build from source as a workaround, however, it takes too much time on the CI worker.
@@ -67,10 +65,8 @@ environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PRO
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
-  "brew link --force ffmpeg@2.8",
+  "brew install eigen libyaml fftw ffmpeg libsamplerate libtag",
   "brew install chromaprint",
-  "brew link --overwrite ffmpeg@2.8",
   # Delocate checks for the min OS version (LC_BUILD_VERSION or C_VERSION_MIN_MACOSX).
   # Tensorflow bottle a has minimum target of 15.2 which is too new.
   # We could build from source as a workaround, however, it takes too much time on the CI worker.
@@ -91,17 +87,5 @@ before-all = [
   "sed 's/^name *= *\"essentia\"$/name = \"essentia-tensorflow\"/' pyproject.toml > pyproject.toml.patched && mv pyproject.toml.patched pyproject.toml"
 ]
 
-# On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and
-# libavutil.54.31.100, depend on libSDL1.2-compat, which is a compatibility
-# layer for SDL2. libSDL1.2-compat expects SDL2 to be installed in the default
-# brew location (i.e., /opt/homebrew/opt/sdl2/lib), so the user would need to
-# install it via brew manually. Alternativelly, we can manualy copy the SDL2
-# libs into the wheel. This is a temporary solution, and in the long term we
-# should move to FFmpeg > 2.X.
-repair-wheel-command = [
-  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
-  "mkdir -p {dest_dir}/essentia/.dylibs",
-  "cp /opt/homebrew/opt/sdl2/lib/libSDL2*.dylib {dest_dir}/essentia/.dylibs",
-  "wheel_rel=$(echo {wheel} | grep -o '[^/]*$')",
-  "cd {dest_dir} && zip -u {dest_dir}/$wheel_rel essentia/.dylibs/*"
-]
+# With Homebrew FFmpeg, delocate can bundle linked dylibs directly.
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -26,10 +26,8 @@ environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}"
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
-  "brew link --force ffmpeg@2.8",
+  "brew install eigen libyaml fftw ffmpeg libsamplerate libtag",
   "brew install chromaprint",
-  "brew link --overwrite ffmpeg@2.8",
   #"brew tap MTG/essentia",
   #"brew install gaia --HEAD",
   # Override VIRTUAL_ENV set by cibuildwheel to ensure global install
@@ -49,27 +47,13 @@ environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}"
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
-  "brew link --force ffmpeg@2.8",
+  "brew install eigen libyaml fftw ffmpeg libsamplerate libtag",
   "brew install chromaprint",
-  "brew link --overwrite ffmpeg@2.8",
   # Override VIRTUAL_ENV set by cibuildwheel to ensure global install
   "VIRTUAL_ENV=/usr/local python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
   "sudo python waf install",
 ]
 
-# On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and
-# libavutil.54.31.100, depend on libSDL1.2-compat, which is a compatibility
-# layer for SDL2. libSDL1.2-compat expects SDL2 to be installed in the default
-# brew location (i.e., /opt/homebrew/opt/sdl2/lib), so the user would need to
-# install it via brew manually. Alternativelly, we can manualy copy the SDL2
-# libs into the wheel. This is a temporary solution, and in the long term we
-# should move to FFmpeg > 2.X.
-repair-wheel-command = [
-  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
-  "mkdir -p {dest_dir}/essentia/.dylibs",
-  "cp /opt/homebrew/opt/sdl2/lib/libSDL2*.dylib {dest_dir}/essentia/.dylibs",
-  "wheel_rel=$(echo {wheel} | grep -o '[^/]*$')",
-  "cd {dest_dir} && zip -u {dest_dir}/$wheel_rel essentia/.dylibs/*"
-]
+# With Homebrew FFmpeg, delocate can bundle linked dylibs directly.
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"


### PR DESCRIPTION
### Motivation

- Validate cibuildwheel workflows on both Linux and macOS so both config paths are exercised in CI. 
- Avoid brittle `brew link` hacks for the old `ffmpeg@2.8` bottle and use the current Homebrew `ffmpeg` package. 
- Replace a manual SDL2 copy-and-zip repair step with a simpler `delocate-wheel` invocation since Homebrew FFmpeg now allows delocate to bundle dylibs directly.

### Description

- Update `.github/workflows/build-wheels-cibuildwheel.yml` to add `fail-fast: false` and expand the matrix `os` from only `ubuntu-latest` to `ubuntu-latest`, `macos-13`, and `macos-14`.
- In `cibuildwheel.toml` and `cibuildwheel-tensorflow.toml` replace `brew install ... ffmpeg@2.8` and the corresponding `brew link`/`brew link --overwrite` lines with `brew install ... ffmpeg` to use the current FFmpeg bottles.
- Remove the multi-step `repair-wheel-command` that manually copied `SDL2` dylibs and update it to a single `repair-wheel-command` string: `delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}`.
- Preserve existing build steps such as running `waf` and the package name monkey-patch in the `before-all` sections.

### Testing

- The GitHub Actions workflow `Build Python wheels (cibuildwheel)` is configured to run on `push` and `pull_request` and will exercise the matrix for `ubuntu-latest`, `macos-13`, and `macos-14`.
- No automated test runs were executed as part of this PR; CI will run the updated matrix on the next push or pull request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ed6af8dc833290cb382ed237a407)