### PR TITLE
CI: enable cibuildwheel job on macOS 26 runners

### DIFF
--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # Build wheels on Linux and macOS to keep both cibuildwheel
         # configuration paths validated in CI.
-        os: [ubuntu-latest, macos-26-intel]
+        os: [ubuntu-latest, macos-26, macos-26-intel]
         config: [cibuildwheel, cibuildwheel-tensorflow]
 
     steps:


### PR DESCRIPTION
### Motivation
- `cibuildwheel` ワークフローは macOS を `macos-26-intel` のみで検証していたため、標準の `macos-26` ランナーでもホイールビルドを検証できるようにするため。

### Description
- `.github/workflows/build-wheels-cibuildwheel.yml` のジョブマトリクス `os` を ` [ubuntu-latest, macos-26, macos-26-intel]` に変更した。

### Testing
- ワークフロー変更のため自動テストは実行しておらず（ワークフローのみの変更）、ファイル差分とコミットを確認して変更は正常に反映された。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4cca2fbc083329383c712b3856158)