### PR TITLE
Modernize packaging scripts: switch to Python 3, require Python>=3.9, secure download URLs, and update metadata

### DIFF
--- a/packaging/darwin/darwin_build_tools.py
+++ b/packaging/darwin/darwin_build_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2006-2021  Music Technology Group - Universitat Pompeu Fabra
 #
@@ -38,7 +38,7 @@ def copy_examples(essentia_root_dir, build_dir, target_dir):
     allfiles = headers + sources + programs + python_examples + libvamp
     ret = 0
     for file in allfiles:
-        print 'copying:', file, 'to', target_dir
+        print('copying:', file, 'to', target_dir)
         ret += subprocess.call(['cp', '-rf', file, target_dir])
 
     return ret
@@ -68,7 +68,7 @@ def removeDSSTORE(dir):
     for file in files:
         if os.path.isdir(file): removeDSSTORE(file)
         else:
-            if file == ds_file: print "removing", file
+            if file == ds_file: print("removing", file)
     ret = 0
     #print 'files:', files
     #ret = 0
@@ -92,7 +92,7 @@ def timeToString():
 def buildPackage(pkg_dir, essentia_root):
     packageMaker = '/Developer/Applications/Utilities/PackageMaker.app/Contents/MacOS/PackageMaker'
     if not os.path.exists(packageMaker):
-        print "Error building package. Could not find PackageMaker application"
+        print("Error building package. Could not find PackageMaker application")
         return 1
 
     root_dir = pkg_dir # path to where the distribution has been created
@@ -130,52 +130,52 @@ if __name__ == '__main__':
     from optparse import OptionParser
     opt,args = OptionParser().parse_args()
     if (len(args) < 2):
-        print 'error while finalising osx package: wrong number of arguments'
-        print '\tusage: ./osx_finalise.py essentia_source_directory essentia_target_directory'
+        print('error while finalising osx package: wrong number of arguments')
+        print('\tusage: ./osx_finalise.py essentia_source_directory essentia_target_directory')
         sys.exit(1)
 
     build_dir = args[0]
     essentia_root_dir = "/".join(build_dir.split('/')[:-1])
     target_dir = args[1]
-    print '*'*70
-    print 'build_dir:', build_dir
-    print 'essentia_dir:', essentia_root_dir
-    print 'target_dir:', target_dir
-    print '*'*70
+    print('*'*70)
+    print('build_dir:', build_dir)
+    print('essentia_dir:', essentia_root_dir)
+    print('target_dir:', target_dir)
+    print('*'*70)
 
-    print '\n'
-    print '*'*70
-    print '* copying examples to', target_dir
+    print('\n')
+    print('*'*70)
+    print('* copying examples to', target_dir)
     if copy_examples(essentia_root_dir,             # where essentia src lives
                      join(build_dir,'examples'),    # where examples are built
                      join(target_dir, 'examples')): # where we want to copy examples
-        print "An error occurred while finalising osx package: error while\
-        copying examples"
+        print("An error occurred while finalising osx package: error while\
+        copying examples")
         sys.exit(1)
 
-    print '* copying documentation to', target_dir
+    print('* copying documentation to', target_dir)
     if copy_documentation(essentia_root_dir, target_dir):
-        print "An error occurred while finalising osx package: error while\
-        copying documentation"
+        print("An error occurred while finalising osx package: error while\
+        copying documentation")
         sys.exit(2)
 
-    print '* removing \".DS_Store\" files from', target_dir
+    print('* removing \".DS_Store\" files from', target_dir)
     if removeDSSTORE(target_dir):
-        print "An error occurred while finalising osx package: "\
-              " could not delete all \".DS_Store\" files."
+        print("An error occurred while finalising osx package: "\
+              " could not delete all \".DS_Store\" files.")
         sys.exit(3)
 
-    print '* copying tests from', essentia_root_dir, 'to', target_dir
+    print('* copying tests from', essentia_root_dir, 'to', target_dir)
     if copy_python_tests(essentia_root_dir, target_dir):
-        print "An error occurred while finalising osx package: "\
-              " could not copy unittest files."
+        print("An error occurred while finalising osx package: "\
+              " could not copy unittest files.")
         sys.exit(3)
 
     pkg_dir = PKG_DIR
-    print '* creating distribution pkg in', pkg_dir
+    print('* creating distribution pkg in', pkg_dir)
     if subprocess.call(['mkdir', pkg_dir]):
-        print "An error occurred while finalising osx package: could not "\
-              "create", pkg_dir
+        print("An error occurred while finalising osx package: could not "\
+              "create", pkg_dir)
         sys.exit(4)
 
     # store where usr and Library are before moving them:
@@ -183,60 +183,59 @@ if __name__ == '__main__':
     library_dir = join(build_dir, 'Library')
 
     if subprocess.call(['mkdir', join(pkg_dir,'usr')]):
-        print "An error occurred while finalising osx package: could not "\
-              "create directory:", join(pkg_dir,'usr')
+        print("An error occurred while finalising osx package: could not "\
+              "create directory:", join(pkg_dir,'usr'))
 
     if subprocess.call(['cp', '-r', usr_dir, join(pkg_dir,'usr', 'local')]):
-        print "An error occurred while finalising osx package: could not "\
-              "move", usr_dir, "to", pkg_dir
+        print("An error occurred while finalising osx package: could not "\
+              "move", usr_dir, "to", pkg_dir)
         sys.exit(5)
 
     if subprocess.call(['mv', library_dir, pkg_dir]):
-        print "An error occurred while finalising osx package: could not "\
-              "move", library_dir, "to", pkg_dir
+        print("An error occurred while finalising osx package: could not "\
+              "move", library_dir, "to", pkg_dir)
         sys.exit(6)
 
     if subprocess.call(['mv', target_dir, pkg_dir]):
-        print "An error occurred while finalising osx package: could not "\
-              "copy ", target_dir, "to", pkg_dir
+        print("An error occurred while finalising osx package: could not "\
+              "copy ", target_dir, "to", pkg_dir)
         sys.exit(7)
 
 
     # change ownership of usr folder to root:wheel:
     usr_dir = join(pkg_dir, 'usr')
-    print '* changing ownership of ', usr_dir, 'to root:wheel'
+    print('* changing ownership of ', usr_dir, 'to root:wheel')
     if chown(usr_dir, 'root', 'wheel', True):
-        print "An error occurred while finalising osx package: "\
-              "could not change ownership of \"usr\" folder"
+        print("An error occurred while finalising osx package: "\
+              "could not change ownership of \"usr\" folder")
         sys.exit(8)
 
     # change ownership of Library folder to root:admin:
     library_dir = join(pkg_dir, 'Library')
-    print '* changing ownership of ', library_dir, 'to root:admin'
+    print('* changing ownership of ', library_dir, 'to root:admin')
     if chown(library_dir, 'root', 'admin', True):
-        print "An error occurred while finalising osx package: error while "\
-              "changing ownership of \"Library\" folder"
+        print("An error occurred while finalising osx package: error while "\
+              "changing ownership of \"Library\" folder")
         sys.exit(9)
 
-    print "* Building Package..."
+    print("* Building Package...")
     if buildPackage(PKG_DIR, essentia_root_dir):
-        print "An error occurred while finalising osx package: error while "\
-              "creating the package"
+        print("An error occurred while finalising osx package: error while "\
+              "creating the package")
         # osx packageMaker failed, but distribuiton package was done succesfully:
-        print '\n'
-        print "*"*70
-        print "* osx distribution build successful. You may find it in", pkg_dir
-        print "* in order to build the package you must use PackageMaker found in "\
-              "* /Developer"
-        print "*"*70
-        print '\n'
+        print('\n')
+        print("*"*70)
+        print("* osx distribution build successful. You may find it in", pkg_dir)
+        print("* in order to build the package you must use PackageMaker found in "\
+              "* /Developer")
+        print("*"*70)
+        print('\n')
         sys.exit(0)
     else:
-        print '\n'
-        print "*"*70
-        print "* osx package build successful. You may find it in your root "\
-              "directory"
-        print "*"*70
-        print '\n'
+        print('\n')
+        print("*"*70)
+        print("* osx package build successful. You may find it in your root "\
+              "directory")
+        print("*"*70)
+        print('\n')
         sys.exit(0)
-

--- a/packaging/darwin/extras/python_version.py
+++ b/packaging/darwin/extras/python_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2006-2021  Music Technology Group - Universitat Pompeu Fabra
 #
@@ -19,17 +19,15 @@
 
 
 
-# this script is used in the preinstall stage to find out whether python2.5 is
-# installed
+# This script is used in the preinstall stage to validate that the interpreter
+# version is supported by current packaging.
 
 import sys
 
-def isCorrectVersion() :
-    version = sys.version.split()[0].split('.')
-    return int(version[0]) >= 2 and int(version[1]) >= 5
+
+def is_supported_version() -> bool:
+    return sys.version_info >= (3, 9)
 
 
 if __name__ == '__main__':
-    if isCorrectVersion():
-        sys.exit(0);
-    else: sys.exit(1);
+    sys.exit(0 if is_supported_version() else 1)

--- a/packaging/darwin/extras/tbb_linker.py
+++ b/packaging/darwin/extras/tbb_linker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2006-2021  Music Technology Group - Universitat Pompeu Fabra
 #
@@ -30,7 +30,7 @@ tbb_src = essentia_third_party + 'tbb20_020oss_src/'
 
 def link(source, target):
     cmd = 'sudo ln -s' + ' ' + source + ' ' + target
-    print cmd
+    print(cmd)
     return os.system(cmd);
 
 def link_tbb_files() :
@@ -55,5 +55,5 @@ def link_tbb_files() :
 
 if __name__ == '__main__':
     ret = link_tbb_files();
-    print "returning ", ret
+    print("returning ", ret)
     exit(ret)

--- a/packaging/darwin/scripts/postinstall
+++ b/packaging/darwin/scripts/postinstall
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 from os.path import join
 

--- a/packaging/debian_3rdparty/build_fftw3.sh
+++ b/packaging/debian_3rdparty/build_fftw3.sh
@@ -8,7 +8,7 @@ cd tmp
 
 echo "Building fftw $FFTW_VERSION"
 
-curl -SLO http://www.fftw.org/$FFTW_VERSION.tar.gz
+curl -SLO https://www.fftw.org/$FFTW_VERSION.tar.gz
 tar -xf $FFTW_VERSION.tar.gz
 cd $FFTW_VERSION
 

--- a/packaging/debian_3rdparty/build_lame.sh
+++ b/packaging/debian_3rdparty/build_lame.sh
@@ -9,7 +9,7 @@ cd tmp
 echo "Building lame $LAME_VERSION"
 
 #!/usr/bin/env bash
-curl -SL -o lame-$LAME_VERSION.tar.gz "http://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Flame%2F&ts=1476009914&use_mirror=ufpr"
+curl -SL -o lame-$LAME_VERSION.tar.gz "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar -xf  lame-$LAME_VERSION.tar.gz
 cd lame-$LAME_VERSION
 CPPFLAGS=-fPIC ./configure --prefix=$PREFIX \

--- a/packaging/debian_3rdparty/build_libsamplerate.sh
+++ b/packaging/debian_3rdparty/build_libsamplerate.sh
@@ -8,7 +8,7 @@ cd tmp
 
 echo "Building libsamplerate $LIBSAMPLERATE_VERSION"
 
-curl -SLO http://www.mega-nerd.com/SRC/$LIBSAMPLERATE_VERSION.tar.gz
+curl -SLO https://www.mega-nerd.com/SRC/$LIBSAMPLERATE_VERSION.tar.gz
 tar -xf $LIBSAMPLERATE_VERSION.tar.gz
 cd $LIBSAMPLERATE_VERSION
 

--- a/packaging/debian_3rdparty/build_taglib.sh
+++ b/packaging/debian_3rdparty/build_taglib.sh
@@ -8,7 +8,7 @@ cd tmp
 
 echo "Building taglib $TAGLIB_VERSION"
 
-curl -SLO http://taglib.github.io/releases/$TAGLIB_VERSION.tar.gz
+curl -SLO https://taglib.org/releases/$TAGLIB_VERSION.tar.gz
 tar -xf $TAGLIB_VERSION.tar.gz
 cd $TAGLIB_VERSION/
 
@@ -26,4 +26,3 @@ make install
 
 cd ../..
 rm -r tmp
-

--- a/packaging/debian_3rdparty/build_yaml.sh
+++ b/packaging/debian_3rdparty/build_yaml.sh
@@ -8,7 +8,7 @@ cd tmp
 
 echo "Building libyaml $LIBYAML_VERSION"
 
-curl -SLO http://pyyaml.org/download/libyaml/$LIBYAML_VERSION.tar.gz
+curl -SLO https://pyyaml.org/download/libyaml/$LIBYAML_VERSION.tar.gz
 tar -xf $LIBYAML_VERSION.tar.gz
 cd $LIBYAML_VERSION
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "essentia"
 license = "AGPL-3.0-only"
+requires-python = ">=3.9"
 dynamic = ["version", "description", "readme", "authors", "keywords", "classifiers", "urls"]
 dependencies = [
     "numpy>=1.25",

--- a/setup.py
+++ b/setup.py
@@ -123,8 +123,12 @@ classifiers = [
     #'Operating System :: Microsoft :: Windows',
     'Programming Language :: C++',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 
 description = 'Library for audio and music analysis, description and synthesis'


### PR DESCRIPTION
### Motivation
- Modernize packaging and installer helper scripts to run on Python 3 and drop legacy Python 2 assumptions. 
- Enforce a minimum supported Python version for packaging and wheel generation to avoid runtime incompatibilities. 
- Use secure `https` download URLs for third-party build scripts to improve transport security.

### Description
- Updated shebangs to `#!/usr/bin/env python3` and converted print statements to the Python 3 `print()` form in Darwin packaging scripts (`packaging/darwin/*.py`, `packaging/darwin/scripts/postinstall`).
- Reworked `packaging/darwin/extras/python_version.py` to use `sys.version_info` and renamed to `is_supported_version()` returning `True` only for Python versions `>= 3.9`, with an appropriate exit code.
- Small improvements to `tbb_linker.py` output formatting and exit handling.
- Replaced `http://` with `https://` in Debian third-party build scripts (`packaging/debian_3rdparty/*_build_*.sh`) and simplified some download URLs to remove unstable query strings.
- Added `requires-python = ">=3.9"` to `pyproject.toml` and updated `setup.py` classifiers to remove Python 2 and list supported Python 3 versions (`3.9`–`3.13`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51f9beb9c8332999cfe299e6056cd)