### PR TITLE
Use explicit `essentia` dependency for Python bindings to fix Windows link failures

### DIFF
--- a/src/python/wscript
+++ b/src/python/wscript
@@ -48,6 +48,11 @@ def build(ctx):
                       # system python path
                       os.path.join(ctx.env.PYTHONDIR, 'numpy', 'core', 'include') ]
 
+    # NOTE:
+    # Keep `use` as an explicit list. A trailing whitespace in a string value
+    # can make local target resolution brittle on some toolchains (notably
+    # MSVC/Windows builds), which may drop the `essentia` static library from
+    # the link step and surface as many unresolved externals from core symbols.
     pybindings = ctx.shlib(
         source   = ctx.path.ant_glob('essentia.cpp parsing.cpp pytypes/*.cpp'),
         target   = '_essentia',
@@ -55,7 +60,7 @@ def build(ctx):
         includes = NUMPY_INCPATH + [ '.', 'pytypes' ] + (ctx.env.INCLUDES_ESSENTIA if ctx.env.ONLY_PYTHON else adjust(ctx.env.INCLUDES, '..')),
         cxxflags = [ '-w' ],
         install_path = '${PYTHONDIR}/essentia',
-        use      = ctx.env.USE_LIBS if ctx.env.ONLY_PYTHON else 'essentia ' #+ ctx.env.USE_LIBS
+        use      = ctx.env.USE_LIBS if ctx.env.ONLY_PYTHON else ['essentia'] # + ctx.env.USE_LIBS
     )
 
     ctx.install_files('${PYTHONDIR}', ctx.path.ant_glob('essentia/**/*.py'),


### PR DESCRIPTION
### Motivation
- Windows/MSVC link failures occurred when building the Python extension because the `use` declaration in the Waf rule was a whitespace-suffixed string which could be parsed incorrectly and drop the local `essentia` target, producing many unresolved core symbols. 

### Description
- Change `src/python/wscript` to declare the Python extension `use` dependency as an explicit list (`['essentia']`) instead of a whitespace-suffixed string and add a short note explaining why the list form is required for robust local target resolution on Windows. 

### Testing
- Ran `python -m py_compile src/python/wscript` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63e6f54b48332aeaeb158bb8d73d2)