### PR TITLE
Make Python extension link target explicit and enforce MSVC dynamic runtime

### DIFF
--- a/src/python/wscript
+++ b/src/python/wscript
@@ -48,6 +48,11 @@ def build(ctx):
                       # system python path
                       os.path.join(ctx.env.PYTHONDIR, 'numpy', 'core', 'include') ]
 
+    # NOTE:
+    # Keep `use` as an explicit list. A trailing whitespace in a string value
+    # can make local target resolution brittle on some toolchains (notably
+    # MSVC/Windows builds), which may drop the `essentia` static library from
+    # the link step and surface as many unresolved externals from core symbols.
     pybindings = ctx.shlib(
         source   = ctx.path.ant_glob('essentia.cpp parsing.cpp pytypes/*.cpp'),
         target   = '_essentia',
@@ -55,7 +60,7 @@ def build(ctx):
         includes = NUMPY_INCPATH + [ '.', 'pytypes' ] + (ctx.env.INCLUDES_ESSENTIA if ctx.env.ONLY_PYTHON else adjust(ctx.env.INCLUDES, '..')),
         cxxflags = [ '-w' ],
         install_path = '${PYTHONDIR}/essentia',
-        use      = ctx.env.USE_LIBS if ctx.env.ONLY_PYTHON else 'essentia ' #+ ctx.env.USE_LIBS
+        use      = ctx.env.USE_LIBS if ctx.env.ONLY_PYTHON else ['essentia'] # + ctx.env.USE_LIBS
     )
 
     ctx.install_files('${PYTHONDIR}', ctx.path.ant_glob('essentia/**/*.py'),

--- a/wscript
+++ b/wscript
@@ -125,6 +125,12 @@ def configure(ctx):
         ctx.env.CXXFLAGS += ['-pipe', '-Wall']
     else:
         ctx.env.CXXFLAGS += ['-W2', '-EHsc']
+        # Build with the dynamic MSVC runtime on Windows.
+        # Python extension modules are compiled/linked with /MD, so forcing the
+        # same runtime here prevents LNK2038 RuntimeLibrary mismatches when the
+        # `_essentia` module links against the local `essentia` static library.
+        ctx.env.CXXFLAGS += ['/MD']
+        ctx.env.CFLAGS += ['/MD']
 
     # Force using SSE floating point for all x86 platforms (default for 64-bit
     # in gcc) instead of 387 floating point (used for 32-bit in gcc) to avoid


### PR DESCRIPTION
### Motivation
- Prevent fragile local target resolution for the Python extension which could drop the `essentia` static library from the link step on some toolchains. 
- Avoid MSVC runtime library mismatches (LNK2038) between the `_essentia` Python module and the local `essentia` static library on Windows. 

### Description
- Change the `use` argument for the Python shared library in `src/python/wscript` from a trailing-space string to an explicit list (`['essentia']`) to avoid brittle target resolution. 
- Add `/MD` to `ctx.env.CXXFLAGS` and `ctx.env.CFLAGS` on Windows in `wscript` so the project builds with the dynamic MSVC runtime to match Python extension modules. 
- Add a clarifying comment in `src/python/wscript` explaining why `use` must be an explicit list. 

### Testing
- Ran `waf configure` and `waf build` (default release) in CI on Linux with `gcc`, and the build completed successfully. 
- Ran the Windows CI build with MSVC to verify runtime linkage, and the build completed successfully, resolving the previous runtime mismatch issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63e6f54b48332aeaeb158bb8d73d2)