### PR TITLE
Improve Windows build flags, fix Python bindings linkage, and robustly locate installed package under tmp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,26 @@ class EssentiaBuildExtension(build_ext):
         subprocess.run([PYTHON, 'waf'], check=True)
         subprocess.run([PYTHON, 'waf', 'install'], check=True)
 
-        library = glob.glob('tmp/lib/python*/*-packages/essentia')[0]
+        # Locate installed python package path across platforms.
+        candidate_patterns = [
+            # POSIX installs via waf/python distutils.
+            os.path.join('tmp', 'lib', 'python*', '*-packages', 'essentia'),
+            # Windows installs.
+            os.path.join('tmp', 'Lib', 'site-packages', 'essentia'),
+            # Alternate lowercase variant (some environments).
+            os.path.join('tmp', 'lib', 'site-packages', 'essentia'),
+        ]
+        matches = []
+        for pattern in candidate_patterns:
+            matches.extend(glob.glob(pattern))
+
+        if not matches:
+            raise RuntimeError(
+                "Could not locate installed essentia package directory under tmp/. "
+                f"Tried: {candidate_patterns}"
+            )
+
+        library = matches[0]
 
 
 def get_git_version():

--- a/src/python/wscript
+++ b/src/python/wscript
@@ -48,6 +48,11 @@ def build(ctx):
                       # system python path
                       os.path.join(ctx.env.PYTHONDIR, 'numpy', 'core', 'include') ]
 
+    # NOTE:
+    # Keep `use` as an explicit list. A trailing whitespace in a string value
+    # can make local target resolution brittle on some toolchains (notably
+    # MSVC/Windows builds), which may drop the `essentia` static library from
+    # the link step and surface as many unresolved externals from core symbols.
     pybindings = ctx.shlib(
         source   = ctx.path.ant_glob('essentia.cpp parsing.cpp pytypes/*.cpp'),
         target   = '_essentia',
@@ -55,7 +60,7 @@ def build(ctx):
         includes = NUMPY_INCPATH + [ '.', 'pytypes' ] + (ctx.env.INCLUDES_ESSENTIA if ctx.env.ONLY_PYTHON else adjust(ctx.env.INCLUDES, '..')),
         cxxflags = [ '-w' ],
         install_path = '${PYTHONDIR}/essentia',
-        use      = ctx.env.USE_LIBS if ctx.env.ONLY_PYTHON else 'essentia ' #+ ctx.env.USE_LIBS
+        use      = ctx.env.USE_LIBS if ctx.env.ONLY_PYTHON else ['essentia'] # + ctx.env.USE_LIBS
     )
 
     ctx.install_files('${PYTHONDIR}', ctx.path.ant_glob('essentia/**/*.py'),

--- a/wscript
+++ b/wscript
@@ -118,13 +118,32 @@ def configure(ctx):
     ctx.env.WITH_CPPTESTS = ctx.options.WITH_CPPTESTS
 
     # compiler flags
-    ctx.env.CXXFLAGS = ['-std=' + ctx.options.STD]  # c++11 by default
+    if sys.platform == 'win32':
+        # `cl` does not understand GCC-style `-std=...` flags (warning D9002).
+        # Map requested language standard to MSVC form where available.
+        msvc_std_map = {
+            'c++14': '/std:c++14',
+            'c++17': '/std:c++17',
+            'c++20': '/std:c++20',
+            'c++23': '/std:c++latest',
+        }
+        # MSVC has no dedicated `/std:c++11`; its default mode already supports
+        # required C++11 features used by Essentia, so omit a std flag for that.
+        ctx.env.CXXFLAGS = [msvc_std_map[ctx.options.STD]] if ctx.options.STD in msvc_std_map else []
+    else:
+        ctx.env.CXXFLAGS = ['-std=' + ctx.options.STD]  # c++11 by default
 
     if sys.platform != 'win32':
         # msvc does not support -pipe
         ctx.env.CXXFLAGS += ['-pipe', '-Wall']
     else:
         ctx.env.CXXFLAGS += ['-W2', '-EHsc']
+        # Build with the dynamic MSVC runtime on Windows.
+        # Python extension modules are compiled/linked with /MD, so forcing the
+        # same runtime here prevents LNK2038 RuntimeLibrary mismatches when the
+        # `_essentia` module links against the local `essentia` static library.
+        ctx.env.CXXFLAGS += ['/MD']
+        ctx.env.CFLAGS += ['/MD']
 
     # Force using SSE floating point for all x86 platforms (default for 64-bit
     # in gcc) instead of 387 floating point (used for 32-bit in gcc) to avoid


### PR DESCRIPTION
### Motivation
- Ensure the build works reliably across Windows and POSIX by mapping C++ standard flags to MSVC and aligning runtime flags to avoid linker/runtime mismatches.
- Prevent brittle local target resolution for the `_essentia` Python extension on some toolchains by making the `use` dependency an explicit list instead of a whitespace-trailing string.
- Make `setup.py` robustly locate the installed `essentia` Python package under `tmp/` for different install layouts and surface a clear error when not found.

### Description
- Update top-level `wscript` to translate `-std=` requests into MSVC `/std:` equivalents on Windows, avoid `-std=` with `cl`, and add `/MD` to `CXXFLAGS` and `CFLAGS` so the dynamic MSVC runtime is used during builds.
- Change `src/python/wscript` to pass `use = ['essentia']` (explicit list) for the Python extension instead of a string with trailing whitespace to avoid missing the static library during linking on some toolchains.
- Enhance `setup.py` to search multiple candidate patterns under `tmp/` (POSIX `*-packages`, `Lib/site-packages`, and `lib/site-packages`) using `glob`, collect matches, and raise a `RuntimeError` with a useful message if no installed package directory is found.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63e6f54b48332aeaeb158bb8d73d2)