### PR TITLE
Fix Windows wheel build by discovering installed `essentia` package in site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import os
 import glob
 import subprocess
 import sys
+import site
+import sysconfig
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install_lib import install_lib
@@ -95,14 +97,35 @@ class EssentiaBuildExtension(build_ext):
             # Alternate lowercase variant (some environments).
             os.path.join('tmp', 'lib', 'site-packages', 'essentia'),
         ]
+        # Some waf + setuptools build environments (notably Windows cibuildwheel)
+        # install the package directly into the active interpreter site-packages
+        # while still honoring --prefix for non-Python artifacts.
+        candidate_paths = []
+        for key in ('purelib', 'platlib'):
+            path = sysconfig.get_paths().get(key)
+            if path:
+                candidate_paths.append(os.path.join(path, 'essentia'))
+        try:
+            candidate_paths.extend([
+                os.path.join(path, 'essentia') for path in site.getsitepackages()
+            ])
+        except Exception:
+            pass
+        user_site = site.getusersitepackages()
+        if user_site:
+            candidate_paths.append(os.path.join(user_site, 'essentia'))
+
         matches = []
         for pattern in candidate_patterns:
             matches.extend(glob.glob(pattern))
+        for path in candidate_paths:
+            if os.path.isdir(path):
+                matches.append(path)
 
         if not matches:
             raise RuntimeError(
                 "Could not locate installed essentia package directory under tmp/. "
-                f"Tried: {candidate_patterns}"
+                f"Tried: {candidate_patterns + candidate_paths}"
             )
 
         library = matches[0]


### PR DESCRIPTION
### Motivation
- Wheel builds on Windows (cibuildwheel) placed Python files into the active interpreter `site-packages` while the setup logic only looked under `tmp/`, causing `RuntimeError: Could not locate installed essentia package directory under tmp/` during `bdist_wheel`.
- The change aims to make the wheel build robust across environments where `waf install` installs into the build interpreter rather than the `--prefix` tree.

### Description
- Added `import site` and `import sysconfig` to `setup.py` to access interpreter install paths.
- Kept the original `tmp/`-based glob patterns and added fallback discovery using `sysconfig.get_paths()` for `purelib`/`platlib`, `site.getsitepackages()`, and `site.getusersitepackages()` to locate an installed `essentia` package directory.
- Appended discovered site-packages paths to the candidate list and include both pattern and direct-path attempts in the runtime error message for easier CI debugging.

### Testing
- Ran `python -m py_compile setup.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c663a07f10833294556d82cbec8d1a)