### PR TITLE
Fix Windows cibuildwheel optional dependency detection and add smoke tests

### DIFF
--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -98,7 +98,7 @@ jobs:
           }
           & (Join-Path $vcpkgRoot 'bootstrap-vcpkg.bat')
           & (Join-Path $vcpkgRoot 'vcpkg.exe') install --triplet x64-windows `
-            eigen3 fftw3 libsamplerate taglib libyaml ffmpeg pkgconf
+            eigen3 fftw3 libsamplerate taglib libyaml ffmpeg chromaprint pkgconf
 
           $vcpkgInstalled = Join-Path $vcpkgRoot 'installed/x64-windows'
           $eigenInclude = Join-Path $vcpkgInstalled 'include/eigen3'

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -56,3 +56,10 @@ before-all = [
 # With Homebrew FFmpeg, delocate can bundle linked dylibs directly.
 # For arm64, thin universal binaries to arm64 first, then run delocate.
 repair-wheel-command = "python packaging/repair_macos_arm64_wheel.py {wheel} {dest_dir} {delocate_archs}"
+
+
+[tool.cibuildwheel.windows]
+
+skip = ["*cp38*", "*cp3??t*", "*-win32"]
+
+test-command = "python test/smoke/test_optional_dependencies.py"

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,9 @@ class EssentiaBuildExtension(build_ext):
         static_deps_flags = ['--static-dependencies']
         build_static_flags = ['--build-static']
         if sys.platform.startswith('win'):
-            # Avoid linking prepackaged x86 static deps on Windows wheels and
-            # minimize optional dependencies that often miss x64 import libs.
-            windows_flags = ['--fft=KISS', '--lightweight=']
+            # Keep using system-provided dependencies on Windows wheels.
+            # Do not force lightweight/KISS mode: optional deps should be
+            # detected through pkg-config (FFTW, FFmpeg, TagLib, YAML, etc.).
             static_deps_flags = []
 
         pkg_config_path = os.getenv('PKG_CONFIG_PATH')

--- a/test/smoke/test_optional_dependencies.py
+++ b/test/smoke/test_optional_dependencies.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import math
+import os
+import tempfile
+import wave
+
+import essentia
+import essentia.standard as es
+import essentia.streaming as est
+
+
+def _make_test_wav(path: str, sample_rate: int = 44100, seconds: float = 1.0) -> None:
+    nframes = int(sample_rate * seconds)
+    amplitude = 0.25
+    frequency = 440.0
+    with wave.open(path, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        for i in range(nframes):
+            sample = int(32767 * amplitude * math.sin(2.0 * math.pi * frequency * i / sample_rate))
+            wav.writeframesraw(sample.to_bytes(2, byteorder="little", signed=True))
+
+
+def main() -> None:
+    print(f"Essentia version: {essentia.__version__}")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        wav_path = os.path.join(tmpdir, "tone.wav")
+        yaml_path = os.path.join(tmpdir, "pool.yaml")
+        _make_test_wav(wav_path)
+
+        # FFmpeg/libav + libsamplerate-backed loaders.
+        audio = es.MonoLoader(filename=wav_path, sampleRate=16000)()
+        assert len(audio) > 0, "MonoLoader returned empty audio."
+        loader = est.MonoLoader(filename=wav_path)
+        del loader
+
+        # TagLib-backed reader should be constructible/runnable on audio files.
+        metadata = es.MetadataReader(filename=wav_path)()
+        assert len(metadata) >= 6, "MetadataReader returned unexpected output."
+
+        # YAML algorithms.
+        pool = essentia.Pool()
+        pool.add("smoke.value", 1.23)
+        es.YamlOutput(filename=yaml_path)(pool)
+        loaded_pool = es.YamlInput(filename=yaml_path)()
+        assert loaded_pool.descriptorNames(), "YamlInput returned an empty pool."
+
+        # Chromaprint algorithm.
+        fingerprint = es.Chromaprinter(sampleRate=16000)(audio)
+        assert fingerprint, "Chromaprinter returned an empty fingerprint."
+
+    print("Optional dependency smoke test passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Windows wheel builds were forcing `--fft=KISS` and `--lightweight=` which suppressed optional dependency detection and prevented the expected configure summary.
- Ensure Windows CI installs and exposes the same optional libraries (FFTW, FFmpeg/libav, libsamplerate, TagLib, libyaml, Chromaprint) so `waf configure` can detect them via `pkg-config`.
- Add an automated smoke test to exercise representative APIs that depend on those optional libs to catch detection/linking/runtime regressions early.

### Description
- Removed the Windows-only `--fft=KISS` and `--lightweight=` overrides from `setup.py` so Windows builds use system/vcpkg-provided dependencies and allow `waf configure` to detect optional libraries via `pkg-config`.
- Added `chromaprint` to the vcpkg install list in `.github/workflows/build-wheels-cibuildwheel.yml` so Chromaprint is available on the Windows CI runner.
- Added a Windows-specific section to `cibuildwheel.toml` with a `test-command` that runs the new smoke script after wheel build.
- Added `test/smoke/test_optional_dependencies.py` which performs a lightweight runtime smoke test exercising `MonoLoader` / streaming `MonoLoader` (FFmpeg/libav + libsamplerate), `MetadataReader` (TagLib), `YamlOutput` / `YamlInput` (libyaml), and `Chromaprinter` (Chromaprint).

### Testing
- Ran `python -m py_compile setup.py test/smoke/test_optional_dependencies.py` to verify syntax of modified files and the new smoke script; this succeeded.
- No Windows GitHub Actions run was executed in this environment; full verification (configure summary lines and smoke test execution) requires running the updated CI Windows `cibuildwheel` job on GitHub Actions where vcpkg is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6756b0e2c833282f2f8c9da5a6952)