### PR TITLE
Fix cibuildwheel import smoke test quoting across platforms

### DIFF
--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -14,7 +14,7 @@ before-all = [
   "\"${PYBIN}\" waf install"
 ]
 
-test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"
+test-command = "python -c \"import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter\""
 
 
 [tool.cibuildwheel.macos]
@@ -38,7 +38,7 @@ before-all = [
   "python waf install"
 ]
 
-test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"
+test-command = "python -c \"import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter\""
 
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
@@ -69,4 +69,4 @@ repair-wheel-command = "python packaging/repair_macos_arm64_wheel.py {wheel} {de
 
 skip = ["*cp38*", "*cp3??t*", "*-win32"]
 
-test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"
+test-command = "python -c \"import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter\""


### PR DESCRIPTION
### Motivation
- The `cibuildwheel` `test-command` used single-quoted `python -c '...'` snippets which break on Windows command execution and produce `SyntaxError: unterminated string literal`, so the quoting needs to be unified to work across POSIX and Windows shells.

### Description
- Replaced single-quoted `python -c '...'` snippets with TOML-escaped double-quoted `python -c "..."` in `cibuildwheel.toml` for the Linux, macOS, and Windows `test-command` entries.

### Testing
- Verified the updated `test-command` lines with `rg -n "test-command =" cibuildwheel.toml` (showing all three updates); attempted to parse `cibuildwheel.toml` with `tomllib` via `python3` but it failed because `tomllib` is not available in the environment, so TOML parse validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69a28498c8332ace3a4b362a37a73)