### PR TITLE
Fix MSVC Python-extension warning flag conflicts

### DIFF
--- a/src/python/wscript
+++ b/src/python/wscript
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import distutils.sysconfig
 import os
+import sys
 
 
 def options(ctx):
@@ -21,6 +22,16 @@ def configure(ctx):
 
     ctx.check_python_headers(features='pyext')
     ctx.check_python_module('numpy')
+
+    if sys.platform == 'win32':
+        # Waf's Python toolchain defaults may add legacy MSVC flags.
+        # Drop deprecated/contradicting options and use modern C++ exceptions.
+        ctx.env.CFLAGS_PYEXT = [f for f in ctx.env.CFLAGS_PYEXT
+                                if f not in ('/W3', '/GX')]
+        ctx.env.CXXFLAGS_PYEXT = [f for f in ctx.env.CXXFLAGS_PYEXT
+                                  if f not in ('/W3', '/GX')]
+        ctx.env.CFLAGS_PYEXT += ['/EHsc', '/w']
+        ctx.env.CXXFLAGS_PYEXT += ['/EHsc', '/w']
 
     # A monkey patch to remove the -lpythonX.Ym flag. PEP 513 recommends to
     # avoid explicit linking to libpythonX.Y.so.1, however python-config still
@@ -58,7 +69,7 @@ def build(ctx):
         target   = '_essentia',
         features = 'pyext',
         includes = NUMPY_INCPATH + [ '.', 'pytypes' ] + (ctx.env.INCLUDES_ESSENTIA if ctx.env.ONLY_PYTHON else adjust(ctx.env.INCLUDES, '..')),
-        cxxflags = [ '-w' ],
+        cxxflags = ['/w'] if sys.platform == 'win32' else ['-w'],
         install_path = '${PYTHONDIR}/essentia',
         use      = ctx.env.USE_LIBS if ctx.env.ONLY_PYTHON else ['essentia'] # + ctx.env.USE_LIBS
     )


### PR DESCRIPTION
### Motivation
- Windows builds were emitting repeated MSVC warnings (e.g. D9025, D9035/D9036) due to legacy and conflicting flags coming from Waf/python pyext defaults.
- The Python extension build should use a modern MSVC exception model and platform-correct warning-suppression flags to avoid noisy/deprecated options.

### Description
- Import `sys` and add a Windows-only `configure` step in `src/python/wscript` to sanitize pyext flags. 
- Remove legacy/conflicting flags `'/W3'` and `'/GX'` from `ctx.env.CFLAGS_PYEXT` and `ctx.env.CXXFLAGS_PYEXT` on Windows and append `'/EHsc'` and `'/w'` instead.
- Make the Python extension target use `cxxflags = ['/w']` on Windows and `cxxflags = ['-w']` on non-Windows hosts to use the correct compiler flag syntax per platform.
- Change is confined to `src/python/wscript` and does not alter non-Windows behavior.

### Testing
- Ran `python -m py_compile src/python/wscript` and the file compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69a090078833289f5c8e6e7eecbfb)