### PR TITLE
CI: Align MSVC and vcpkg architectures and export VSCMD args in Windows build

### DIFF
--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -71,7 +71,7 @@ jobs:
 
           $envDump = cmd /c "`"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && set"
           foreach ($line in $envDump) {
-            if ($line -match '^(INCLUDE|LIB|LIBPATH|PATH|VCINSTALLDIR|VCToolsInstallDir|VSINSTALLDIR|UniversalCRTSdkDir|UCRTVersion|WindowsLibPath|WindowsSdkBinPath|WindowsSdkDir|WindowsSDKVersion)=(.*)$') {
+            if ($line -match '^(INCLUDE|LIB|LIBPATH|PATH|VCINSTALLDIR|VCToolsInstallDir|VSINSTALLDIR|UniversalCRTSdkDir|UCRTVersion|WindowsLibPath|WindowsSdkBinPath|WindowsSdkDir|WindowsSDKVersion|VSCMD_ARG_HOST_ARCH|VSCMD_ARG_TGT_ARCH)=(.*)$') {
               $name = $matches[1]
               $value = $matches[2]
               "$name=$value" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -86,6 +86,10 @@ jobs:
         if: ${{ startsWith(matrix.os, 'windows') }}
         shell: pwsh
         run: |
+          # Keep vcpkg and MSVC target architecture aligned to avoid x86/x64 mismatch warnings.
+          $env:VSCMD_ARG_HOST_ARCH = 'x64'
+          $env:VSCMD_ARG_TGT_ARCH = 'x64'
+
           $repo = (Get-Location).Path
           $vcpkgRoot = Join-Path $env:RUNNER_TEMP 'vcpkg'
           if (-not (Test-Path $vcpkgRoot)) {


### PR DESCRIPTION
### Motivation

- Ensure MSVC environment variables for target/host architecture are captured and propagated so Windows CI builds use a consistent x64 toolchain and avoid x86/x64 mismatch warnings.

### Description

- Added `VSCMD_ARG_HOST_ARCH` and `VSCMD_ARG_TGT_ARCH` to the regex that extracts environment variables from `VsDevCmd.bat` output so those values are written to `GITHUB_ENV`.
- Set `VSCMD_ARG_HOST_ARCH` and `VSCMD_ARG_TGT_ARCH` to `x64` before running `vcpkg` so `vcpkg` uses the same MSVC target architecture and prevents mismatches. 
- Left existing `vcpkg` bootstrap and package installation steps intact and preserved the verification of the installed Eigen headers.

### Testing

- Ran the `build-wheels-cibuildwheel` GitHub Actions workflow on the Windows matrix and confirmed the Windows job reached the `Prepare Windows pkg-config dependencies` step and completed the `vcpkg` install step successfully. 
- Confirmed that the `VsDevCmd.bat` environment parsing now exports `VSCMD_ARG_HOST_ARCH` and `VSCMD_ARG_TGT_ARCH` into `GITHUB_ENV` during the job run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69ac5e4108332bca2f1d5d5cd62f4)