### PR TITLE
Bundle Windows wheel DLLs with delvewheel in cibuildwheel

### DIFF
--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -69,4 +69,6 @@ repair-wheel-command = "python packaging/repair_macos_arm64_wheel.py {wheel} {de
 
 skip = ["*cp38*", "*cp3??t*", "*-win32"]
 
+before-build = "python -m pip install delvewheel"
+repair-wheel-command = "python -m delvewheel repair --add-path \"%RUNNER_TEMP%\\vcpkg\\installed\\x64-windows\\bin\" --wheel-dir {dest_dir} {wheel}"
 test-command = "python -c \"import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter\""


### PR DESCRIPTION
### Motivation
- Fix Windows wheel import failures where `_essentia` raised `ImportError: DLL load failed while importing _essentia` by ensuring runtime DLLs from vcpkg are included in the wheel.

### Description
- Update `cibuildwheel.toml` to add under `[tool.cibuildwheel.windows]` a `before-build = "python -m pip install delvewheel"` and a `repair-wheel-command` that runs `python -m delvewheel repair --add-path "%RUNNER_TEMP%\vcpkg\installed\x64-windows\bin" --wheel-dir {dest_dir} {wheel}` to vendor vcpkg runtime DLLs into the built wheel.

### Testing
- Validated the edited `cibuildwheel.toml` parses successfully using `tomli` (installed via `python -m pip install tomli`) and `tomli.load`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a879e96c8332ab26fb0ac199a810)