### PR TITLE
Fix optional AudioLoader/Writer checks in Python translate module

### DIFF
--- a/src/python/essentia/translate.py
+++ b/src/python/essentia/translate.py
@@ -269,22 +269,37 @@ def translate(composite_algo, output_filename, dot_graph=False):
     for algo in streaming_algos:
         algo.configure = algo.real_configure
 
+    def _optional_streaming_classes(*class_names):
+        available = []
+        for class_name in class_names:
+            cls = getattr(streaming, class_name, None)
+            if inspect.isclass(cls):
+                available.append(cls)
+        return tuple(available)
+
+    forbidden_audio_loader_classes = _optional_streaming_classes('AudioLoader',
+                                                                 'EasyLoader',
+                                                                 'MonoLoader',
+                                                                 'EqloudLoader')
+    forbidden_audio_writer_classes = _optional_streaming_classes('AudioWriter',
+                                                                 'MonoWriter')
+    forbidden_file_output_classes = _optional_streaming_classes('FileOutput')
+
     ### Do some checking on their network ###
     for algo in [ logitem['instance'] for logitem in configure_log.values() ]:
         if isinstance(algo, streaming.VectorInput):
             raise TypeError('essentia.streaming.VectorInput algorithms are not allowed for translatable composite algorithms')
 
-        if isinstance(algo, streaming.AudioLoader) or \
-           isinstance(algo, streaming.EasyLoader) or \
-           isinstance(algo, streaming.MonoLoader) or \
-           isinstance(algo, streaming.EqloudLoader):
+        if forbidden_audio_loader_classes and \
+           isinstance(algo, forbidden_audio_loader_classes):
             raise TypeError('No type of AudioLoader is allowed for translatable composite algorithms')
 
-        if isinstance(algo, streaming.AudioWriter) or \
-           isinstance(algo, streaming.MonoWriter):
+        if forbidden_audio_writer_classes and \
+           isinstance(algo, forbidden_audio_writer_classes):
             raise TypeError('No type of AudioWriter is allowed for translatable composite algorithms')
 
-        if isinstance(algo, streaming.FileOutput):
+        if forbidden_file_output_classes and \
+           isinstance(algo, forbidden_file_output_classes):
             raise TypeError('essentia.streaming.FileOutput algorithms are not allowed for translatable composite algorithms')
 
 
@@ -582,4 +597,3 @@ const char* '''+composite_algo.__name__+'''::description = DOC("");\n\n'''
         f = open(output_filename+'.dot', 'w')
         f.write(dot_code)
         f.close()
-


### PR DESCRIPTION
### Motivation
- Avoid crashes and static-analysis warnings when optional streaming IO algorithms (e.g. `AudioLoader`, `MonoWriter`, `FileOutput`) are not available in the `streaming` module on some builds (common on Windows). 
- Preserve the original validation intent of `translate()` while making the checks resilient to missing classes.

### Description
- Added a helper `def _optional_streaming_classes(*class_names):` that uses `getattr(streaming, name, None)` and `inspect.isclass` to collect only present classes into tuples. 
- Constructed `forbidden_audio_loader_classes`, `forbidden_audio_writer_classes`, and `forbidden_file_output_classes` as tuples of available classes. 
- Replaced direct attribute references like `isinstance(algo, streaming.AudioLoader)` with guarded checks that first ensure the corresponding tuple is non-empty and then use `isinstance(algo, forbidden_..._classes)`. 
- No behavioral change when those classes are present; the checks now simply skip absent optional classes instead of raising `AttributeError` or confusing linters.

### Testing
- Ran `python -m py_compile src/python/essentia/translate.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c73fc57cc48332aae84ae334c4c4eb)