### PR TITLE
Cache CI dependencies, add Python setup, and reuse cached static deps in cibuildwheel

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,6 +14,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: .github/workflows/build-docs.yml
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+          cache: "pip"
+          cache-dependency-path: .github/workflows/build-wheels-cibuildwheel.yml
 
       - name: Initialize MSVC environment (without ilammy/msvc-dev-cmd)
         if: ${{ startsWith(matrix.os, 'windows') }}
@@ -80,6 +82,24 @@ jobs:
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.4.0
+
+      - name: Cache Linux before-all static dependencies
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        uses: actions/cache@v5
+        with:
+          path: .cibw-cache/essentia-static-deps
+          key: linux-static-deps-${{ matrix.os }}-${{ hashFiles('cibuildwheel.toml', 'packaging/build_3rdparty_static_debian.sh', 'packaging/debian_3rdparty/*.sh') }}
+          restore-keys: |
+            linux-static-deps-${{ matrix.os }}-
+
+      - name: Cache vcpkg dependencies
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/vcpkg
+          key: vcpkg-${{ matrix.os }}-${{ hashFiles('.github/workflows/build-wheels-cibuildwheel.yml') }}
+          restore-keys: |
+            vcpkg-${{ matrix.os }}-
 
 
       - name: Prepare Windows pkg-config dependencies

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -2,12 +2,13 @@
 
 skip = ["*-musllinux*", "*i686", "*cp38*", "*cp3??t*"]
 
-environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=0, PKG_CONFIG_PATH="/tmp/essentia-static-deps/lib/pkgconfig:/tmp/essentia-static-deps/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig" }
+environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=0, PKG_CONFIG_PATH="/project/.cibw-cache/essentia-static-deps/lib/pkgconfig:/project/.cibw-cache/essentia-static-deps/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig" }
 
 before-all = [
   "PYBIN=$(ls -1 /opt/python/cp3*-cp3*/bin/python | head -n 1)",
-  "PREFIX=/tmp/essentia-static-deps bash packaging/build_3rdparty_static_debian.sh",
-  "\"${PYBIN}\" waf configure --build-static --static-dependencies --pkg-config-path=\"/tmp/essentia-static-deps/lib/pkgconfig:/tmp/essentia-static-deps/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}\"",
+  "mkdir -p /project/.cibw-cache/essentia-static-deps",
+  "if [ ! -f /project/.cibw-cache/essentia-static-deps/lib/pkgconfig/fftw3f.pc ]; then PREFIX=/project/.cibw-cache/essentia-static-deps bash packaging/build_3rdparty_static_debian.sh; else echo 'Using cached Linux static dependencies from /project/.cibw-cache/essentia-static-deps'; fi",
+  "\"${PYBIN}\" waf configure --build-static --static-dependencies --pkg-config-path=\"/project/.cibw-cache/essentia-static-deps/lib/pkgconfig:/project/.cibw-cache/essentia-static-deps/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}\"",
   "echo 'Note: libyaml pkg-config module is yaml-0.1 (ABI name); resolved version can be 0.2.x'",
   "echo 'Resolved dependency versions (pkg-config)' && for dep in eigen3 yaml-0.1 fftw3f libavcodec libavformat libavutil libswresample samplerate taglib libchromaprint; do if pkg-config --exists \"$dep\"; then echo \"$dep=$(pkg-config --modversion \"$dep\")\"; else echo \"$dep=not found\"; fi; done",
   "\"${PYBIN}\" waf",


### PR DESCRIPTION
### Motivation
- Improve CI performance and reproducibility by caching Python/pip, Linux static third-party dependencies, and Windows vcpkg dependencies in GitHub Actions workflows.
- Ensure consistent Python runtimes in documentation and wheel build workflows by explicitly setting `actions/setup-python` versions.

### Description
- Added `actions/setup-python@v6` steps to `.github/workflows/build-docs.yml` and `.github/workflows/build-wheels-cibuildwheel.yml` with pinned `python-version` (`3.12` for docs and `3.14` for wheels) and enabled `pip` caching via `cache-dependency-path`.
- Added an Actions cache for Linux static dependencies at `.cibw-cache/essentia-static-deps` and a Windows `vcpkg` cache under the runner temp directory in `.github/workflows/build-wheels-cibuildwheel.yml`.
- Updated `cibuildwheel.toml` to change `PKG_CONFIG_PATH` to use `/project/.cibw-cache/essentia-static-deps` and modified `before-all` to populate or reuse that cache by checking for `fftw3f.pc` and running `packaging/build_3rdparty_static_debian.sh` into the cache only when missing.
- Kept and adjusted existing steps to install dependencies, build Gaia, and build Essentia while integrating the new cache locations and Python setup.

### Testing
- No automated test runs were executed as part of this change; these edits modify CI workflow and `cibuildwheel` configuration and will be exercised on the next CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7402fdc0883328258d19008712c74)