### PR TITLE
Add lazy attribute resolution and PathLike support; guard translate checks

### DIFF
--- a/src/python/essentia/common.py
+++ b/src/python/essentia/common.py
@@ -16,6 +16,7 @@
 # version 3 along with this program. If not, see http://www.gnu.org/licenses/
 
 import numpy
+import os
 from six import iteritems
 from . import _essentia
 
@@ -263,6 +264,11 @@ def determineEdt(obj):
 # Converts 'data' to 'goalType'. 'goalType' must be a non-intermediate EDT. If
 # a conversion cannot be made, a TypeError will be raised.
 def convertData(data, goalType):
+    if goalType == Edt.STRING:
+        path_like_type = getattr(os, 'PathLike', None)
+        if path_like_type is not None and isinstance(data, path_like_type):
+            return os.fspath(data)
+
     origType = determineEdt(data)
 
     if origType == goalType:

--- a/src/python/essentia/standard.py
+++ b/src/python/essentia/standard.py
@@ -144,3 +144,13 @@ _reloadAlgorithms()
 # load derived descriptors and other ones written in python
 from .algorithms import create_python_algorithms as _create_python_algorithms
 _create_python_algorithms(_sys.modules[__name__])
+
+
+def __getattr__(name):
+    # Some binary builds can expose different algorithm sets. Support late
+    # resolution of generated classes and provide a better error when an
+    # algorithm is not available in the current build.
+    if name in _essentia.keys():
+        return _create_essentia_class(name)
+
+    raise AttributeError("module '%s' has no attribute '%s'" % (__name__, name))

--- a/src/python/essentia/standard.pyi
+++ b/src/python/essentia/standard.pyi
@@ -1,0 +1,4 @@
+from typing import Any
+
+
+def __getattr__(name: str) -> Any: ...

--- a/src/python/essentia/streaming.py
+++ b/src/python/essentia/streaming.py
@@ -200,6 +200,17 @@ def _reloadStreamingAlgorithms():
 
 _reloadStreamingAlgorithms()
 
+
+def __getattr__(name):
+    # Some binary builds can expose different algorithm sets. Support late
+    # resolution of generated classes and provide a better error when an
+    # algorithm is not available in the current build.
+    if name in algorithmNames():
+        _create_streaming_algo(name)
+        return getattr(_sys.modules[__name__], name)
+
+    raise AttributeError("module '%s' has no attribute '%s'" % (__name__, name))
+
 # This subclass provides some more functionality for VectorInput
 class VectorInput(_essentia.VectorInput):
     __doc__ = 'VectorInput v1.0\n\n\n'+\

--- a/src/python/essentia/streaming.pyi
+++ b/src/python/essentia/streaming.pyi
@@ -1,0 +1,4 @@
+from typing import Any
+
+
+def __getattr__(name: str) -> Any: ...

--- a/src/python/essentia/translate.py
+++ b/src/python/essentia/translate.py
@@ -269,22 +269,37 @@ def translate(composite_algo, output_filename, dot_graph=False):
     for algo in streaming_algos:
         algo.configure = algo.real_configure
 
+    def _optional_streaming_classes(*class_names):
+        available = []
+        for class_name in class_names:
+            cls = getattr(streaming, class_name, None)
+            if inspect.isclass(cls):
+                available.append(cls)
+        return tuple(available)
+
+    forbidden_audio_loader_classes = _optional_streaming_classes('AudioLoader',
+                                                                 'EasyLoader',
+                                                                 'MonoLoader',
+                                                                 'EqloudLoader')
+    forbidden_audio_writer_classes = _optional_streaming_classes('AudioWriter',
+                                                                 'MonoWriter')
+    forbidden_file_output_classes = _optional_streaming_classes('FileOutput')
+
     ### Do some checking on their network ###
     for algo in [ logitem['instance'] for logitem in configure_log.values() ]:
         if isinstance(algo, streaming.VectorInput):
             raise TypeError('essentia.streaming.VectorInput algorithms are not allowed for translatable composite algorithms')
 
-        if isinstance(algo, streaming.AudioLoader) or \
-           isinstance(algo, streaming.EasyLoader) or \
-           isinstance(algo, streaming.MonoLoader) or \
-           isinstance(algo, streaming.EqloudLoader):
+        if forbidden_audio_loader_classes and \
+           isinstance(algo, forbidden_audio_loader_classes):
             raise TypeError('No type of AudioLoader is allowed for translatable composite algorithms')
 
-        if isinstance(algo, streaming.AudioWriter) or \
-           isinstance(algo, streaming.MonoWriter):
+        if forbidden_audio_writer_classes and \
+           isinstance(algo, forbidden_audio_writer_classes):
             raise TypeError('No type of AudioWriter is allowed for translatable composite algorithms')
 
-        if isinstance(algo, streaming.FileOutput):
+        if forbidden_file_output_classes and \
+           isinstance(algo, forbidden_file_output_classes):
             raise TypeError('essentia.streaming.FileOutput algorithms are not allowed for translatable composite algorithms')
 
 
@@ -582,4 +597,3 @@ const char* '''+composite_algo.__name__+'''::description = DOC("");\n\n'''
         f = open(output_filename+'.dot', 'w')
         f.write(dot_code)
         f.close()
-


### PR DESCRIPTION
### Motivation

- Allow Python callers to access generated algorithm classes lazily and provide clearer errors when an algorithm is not available in the binary build.  
- Accept `os.PathLike` objects for string-converted parameters so filesystem path-like types work with Essentia APIs.  
- Make translate-time checks robust across builds where certain streaming classes may not be present.  

### Description

- Add `__getattr__` to `essentia.standard` to lazily create and return generated algorithm classes when accessed at attribute lookup time.  
- Add a PEP 561-style stub `standard.pyi` exposing `__getattr__` for typing.  
- Add `__getattr__` to `essentia.streaming` to lazily create streaming algorithm classes and return them on attribute access, and add `streaming.pyi` stub.  
- In `common.convertData`, accept `os.PathLike` objects and convert them to string when the goal type is `Edt.STRING`, and add the `os` import.  
- In `translate.translate`, introduce `_optional_streaming_classes` to collect only available streaming classes and use those tuples to guard `isinstance` checks for forbidden loader/writer/file-output types.  

### Testing

- Ran basic automated import and attribute-resolution checks by importing `essentia.standard` and `essentia.streaming` and accessing a few generated algorithm names to verify lazy creation succeeded (passed).  
- Ran a conversion sanity check converting an `os.PathLike` to a string via `convertData(..., Edt.STRING)` (passed).  
- Executed the repository's Python unit test suite and static type stub checks where present, and they completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c73fc57cc48332aae84ae334c4c4eb)