### PR TITLE
Fix AudioLoader metadata emission timing on Windows (defer to process(), add codecpar fallback)

### DIFF
--- a/src/algorithms/io/audioloader.cpp
+++ b/src/algorithms/io/audioloader.cpp
@@ -217,6 +217,33 @@ AlgorithmStatus AudioLoader::process() {
         throw EssentiaException("AudioLoader: Trying to call process() on an AudioLoader algo which hasn't been correctly configured.");
     }
 
+    if (!_metadataSent) {
+        AVCodecParameters* codecParams = 0;
+        if (_demuxCtx && _streamIdx >= 0 && _streamIdx < (int)_demuxCtx->nb_streams &&
+            _demuxCtx->streams[_streamIdx]) {
+            codecParams = _demuxCtx->streams[_streamIdx]->codecpar;
+        }
+
+        int nChannels = _audioCtx ? _audioCtx->ch_layout.nb_channels : 0;
+        if (nChannels <= 0 && codecParams) {
+            nChannels = codecParams->ch_layout.nb_channels;
+        }
+
+        Real sampleRate = _audioCtx ? _audioCtx->sample_rate : 0;
+        if (sampleRate <= 0 && codecParams) {
+            sampleRate = codecParams->sample_rate;
+        }
+
+        int bitRate = _audioCtx ? _audioCtx->bit_rate : 0;
+        if (bitRate <= 0 && codecParams) {
+            bitRate = codecParams->bit_rate;
+        }
+
+        pushChannelsSampleRateInfo(nChannels, sampleRate);
+        pushCodecInfo(_audioCodec ? _audioCodec->name : "", bitRate);
+        _metadataSent = true;
+    }
+
     // read frames until we get a good one
     do {
         int result = av_read_frame(_demuxCtx, &_packet);
@@ -521,24 +548,16 @@ void AudioLoader::reset() {
     closeAudioFile();
     openAudioFile(filename);
 
-    AVCodecParameters* codecParams = 0;
-    if (_demuxCtx && _streamIdx >= 0 && _streamIdx < (int)_demuxCtx->nb_streams &&
-        _demuxCtx->streams[_streamIdx]) {
-        codecParams = _demuxCtx->streams[_streamIdx]->codecpar;
-    }
+    _metadataSent = false;
 
-    int nChannels = _audioCtx->ch_layout.nb_channels;
-    if (nChannels <= 0 && codecParams) {
-        nChannels = codecParams->ch_layout.nb_channels;
+    _nChannels = _audioCtx ? _audioCtx->ch_layout.nb_channels : 0;
+    if (_nChannels <= 0 && _demuxCtx && _streamIdx >= 0 &&
+        _streamIdx < (int)_demuxCtx->nb_streams && _demuxCtx->streams[_streamIdx]) {
+        AVCodecParameters* codecParams = _demuxCtx->streams[_streamIdx]->codecpar;
+        if (codecParams) {
+            _nChannels = codecParams->ch_layout.nb_channels;
+        }
     }
-
-    Real sampleRate = _audioCtx->sample_rate;
-    if (sampleRate <= 0 && codecParams) {
-        sampleRate = codecParams->sample_rate;
-    }
-
-    pushChannelsSampleRateInfo(nChannels, sampleRate);
-    pushCodecInfo(_audioCodec->name, _audioCtx->bit_rate);
 }
 
 } // namespace streaming

--- a/src/algorithms/io/audioloader.h
+++ b/src/algorithms/io/audioloader.h
@@ -66,6 +66,7 @@ class AudioLoader : public Algorithm {
   std::vector<int> _streams;
   int _selectedStream;
   bool _configured;
+  bool _metadataSent;
 
 
   void openAudioFile(const std::string& filename);
@@ -83,7 +84,7 @@ class AudioLoader : public Algorithm {
  public:
   AudioLoader() : Algorithm(), _buffer(0),  _demuxCtx(0),
 	          _audioCtx(0), _audioCodec(0), _decodedFrame(0),
-            _convertCtxAv(0), _configured(false) {
+            _convertCtxAv(0), _configured(false), _metadataSent(false) {
 
     declareOutput(_audio, 1, "audio", "the input audio signal");
     declareOutput(_sampleRate, 0, "sampleRate", "the sampling rate of the audio signal [Hz]");

--- a/test/src/unittests/io/test_audioloader_streaming.py
+++ b/test/src/unittests/io/test_audioloader_streaming.py
@@ -182,6 +182,18 @@ class TestAudioLoader_Streaming(TestCase):
         self.assertEqualMatrix(audio2, audio1)
         self.assertEqualMatrix(audio2, audio3)
 
+    def testStandardMetadataIsPopulated(self):
+        from essentia.standard import AudioLoader as stdAudioLoader
+        filename = join(testdata.audio_dir, 'recorded', 'musicbox.wav')
+        audio, sampleRate, numberChannels, _, bitRate, codec = stdAudioLoader(filename=filename)()
+
+        self.assertTrue(len(audio) > 0)
+        self.assertTrue(sampleRate > 0)
+        self.assertTrue(numberChannels > 0)
+        self.assertTrue(len(codec) > 0)
+        # Some formats/containers may not report a reliable bit rate.
+        self.assertTrue(bitRate >= 0)
+
     def testBitrate(self):
         from math import fabs
         dir = join(testdata.audio_dir,'recorded')


### PR DESCRIPTION
### Motivation
- Root cause: metadata (`sampleRate`, `numberChannels`, `codec`, `bit_rate`) was emitted during `reset()`/configure time while the standard wrapper expects metadata to be pushed while the inner streaming network is running, causing empty/zero metadata even when audio was decoded later.  
- On some Windows FFmpeg builds the codec-context fields can be unset/zero at reset time while `codecpar` holds valid values, exposing the timing bug.  
- The intent is to minimally change emission timing so metadata is pushed once during the active `process()` run and to fall back to stream `codecpar` when codec-context fields are missing.  

### Description
- Added a `_metadataSent` flag and deferred metadata emission from `reset()` to `process()`, emitting metadata exactly once per run when the network is active (`src/algorithms/io/audioloader.h`, `src/algorithms/io/audioloader.cpp`).  
- When emitting metadata, use codec-context fields if present, and fall back to stream `codecpar` for `sample_rate`, channel count and `bit_rate` when codec-context values are zero/empty (`src/algorithms/io/audioloader.cpp`).  
- Preserve initialization required for decoding in `reset()` (still sets internal `_nChannels` for sample-copying) but avoid pushing outputs prematurely (`src/algorithms/io/audioloader.cpp`).  
- Added a regression unit test `testStandardMetadataIsPopulated` in `test/src/unittests/io/test_audioloader_streaming.py` which asserts the standard `AudioLoader` returns non-empty audio, `sampleRate > 0`, `numberChannels > 0`, non-empty `codec`, and `bit_rate >= 0`.

### Testing
- Compiled the new/modified Python test file with `python3 -m py_compile test/src/unittests/io/test_audioloader_streaming.py`, which succeeded.  
- Attempted to run the test script directly (`python3 test/src/unittests/io/test_audioloader_streaming.py`), which failed in this environment due to the test harness not being on `PYTHONPATH` (`ModuleNotFoundError: No module named 'essentia_test'`).  
- Attempted to run the test with `PYTHONPATH=test/src/unittests`, but that produced an environment-specific error unrelated to the change (`AttributeError: module 'io' has no attribute 'open'`) caused by local test path name shadowing; full unit test execution was therefore not possible in this sandbox but the added test is self-contained and should run in CI/test environments where the test harness is available.  
- The change is minimal and targeted; it is expected to pass the existing `AudioLoader` unit tests (including the new regression) in CI on Linux/macOS/Windows where the test harness and FFmpeg are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a5a44b3083329da06280e7c011ed)