### PR TITLE
AudioLoader: emit and cache stream metadata (channels, sample rate, codec, bit_rate) and add test

### DIFF
--- a/src/algorithms/io/audioloader.cpp
+++ b/src/algorithms/io/audioloader.cpp
@@ -217,6 +217,12 @@ AlgorithmStatus AudioLoader::process() {
         throw EssentiaException("AudioLoader: Trying to call process() on an AudioLoader algo which hasn't been correctly configured.");
     }
 
+    if (!_metadataSent) {
+        pushChannelsSampleRateInfo(_metadataChannels, _metadataSampleRate);
+        pushCodecInfo(_metadataCodec, _metadataBitRate);
+        _metadataSent = true;
+    }
+
     // read frames until we get a good one
     do {
         int result = av_read_frame(_demuxCtx, &_packet);
@@ -521,24 +527,40 @@ void AudioLoader::reset() {
     closeAudioFile();
     openAudioFile(filename);
 
+    _metadataSent = false;
+    _metadataChannels = 0;
+    _metadataSampleRate = 0;
+    _metadataBitRate = 0;
+    _metadataCodec = _audioCodec ? _audioCodec->name : "";
+
     AVCodecParameters* codecParams = 0;
     if (_demuxCtx && _streamIdx >= 0 && _streamIdx < (int)_demuxCtx->nb_streams &&
         _demuxCtx->streams[_streamIdx]) {
         codecParams = _demuxCtx->streams[_streamIdx]->codecpar;
     }
 
-    int nChannels = _audioCtx->ch_layout.nb_channels;
-    if (nChannels <= 0 && codecParams) {
-        nChannels = codecParams->ch_layout.nb_channels;
+    _metadataChannels = _audioCtx ? _audioCtx->ch_layout.nb_channels : 0;
+    if (_metadataChannels <= 0 && codecParams) {
+        _metadataChannels = codecParams->ch_layout.nb_channels;
     }
 
-    Real sampleRate = _audioCtx->sample_rate;
-    if (sampleRate <= 0 && codecParams) {
-        sampleRate = codecParams->sample_rate;
+    _metadataSampleRate = _audioCtx ? _audioCtx->sample_rate : 0;
+    if (_metadataSampleRate <= 0 && codecParams) {
+        _metadataSampleRate = codecParams->sample_rate;
     }
 
-    pushChannelsSampleRateInfo(nChannels, sampleRate);
-    pushCodecInfo(_audioCodec->name, _audioCtx->bit_rate);
+    _metadataBitRate = _audioCtx ? _audioCtx->bit_rate : 0;
+    if (_metadataBitRate <= 0 && codecParams) {
+        _metadataBitRate = codecParams->bit_rate;
+    }
+    if (_metadataBitRate <= 0 && _demuxCtx) {
+        _metadataBitRate = _demuxCtx->bit_rate;
+    }
+    if (_metadataBitRate < 0) {
+        _metadataBitRate = 0;
+    }
+
+    _nChannels = _metadataChannels;
 }
 
 } // namespace streaming

--- a/src/algorithms/io/audioloader.h
+++ b/src/algorithms/io/audioloader.h
@@ -66,6 +66,11 @@ class AudioLoader : public Algorithm {
   std::vector<int> _streams;
   int _selectedStream;
   bool _configured;
+  bool _metadataSent;
+  int _metadataChannels;
+  Real _metadataSampleRate;
+  int _metadataBitRate;
+  std::string _metadataCodec;
 
 
   void openAudioFile(const std::string& filename);
@@ -83,7 +88,8 @@ class AudioLoader : public Algorithm {
  public:
   AudioLoader() : Algorithm(), _buffer(0),  _demuxCtx(0),
 	          _audioCtx(0), _audioCodec(0), _decodedFrame(0),
-            _convertCtxAv(0), _configured(false) {
+            _convertCtxAv(0), _configured(false), _metadataSent(false),
+            _metadataChannels(0), _metadataSampleRate(0), _metadataBitRate(0) {
 
     declareOutput(_audio, 1, "audio", "the input audio signal");
     declareOutput(_sampleRate, 0, "sampleRate", "the sampling rate of the audio signal [Hz]");

--- a/test/src/unittests/io/test_audioloader_streaming.py
+++ b/test/src/unittests/io/test_audioloader_streaming.py
@@ -182,6 +182,18 @@ class TestAudioLoader_Streaming(TestCase):
         self.assertEqualMatrix(audio2, audio1)
         self.assertEqualMatrix(audio2, audio3)
 
+    def testStandardMetadataIsPopulated(self):
+        from essentia.standard import AudioLoader as stdAudioLoader
+        filename = join(testdata.audio_dir, 'recorded', 'musicbox.wav')
+        audio, sampleRate, numberChannels, _, bitRate, codec = stdAudioLoader(filename=filename)()
+
+        self.assertTrue(len(audio) > 0)
+        self.assertTrue(sampleRate > 0)
+        self.assertTrue(numberChannels > 0)
+        self.assertTrue(len(codec) > 0)
+        # Some formats/containers may not report a reliable bit rate.
+        self.assertTrue(bitRate >= 0)
+
     def testBitrate(self):
         from math import fabs
         dir = join(testdata.audio_dir,'recorded')


### PR DESCRIPTION
### Motivation
- Ensure the `AudioLoader` emits standard metadata outputs (`sampleRate`, `numberChannels`, `codec`, `bit_rate`) reliably for streaming and standard use by caching codec/container info and emitting it once when processing starts.

### Description
- Add cached metadata fields ` _metadataSent`, `_metadataChannels`, `_metadataSampleRate`, `_metadataBitRate`, and `_metadataCodec` and initialize them in the constructor.
- Populate cached metadata in `reset()` from `AVCodecContext`, stream `codecpar`, and `AVFormatContext` with fallbacks and clamp negative bit rates to zero, and set `_nChannels` from the cached channel count.
- Defer pushing of metadata outputs until the first `process()` call by checking `_metadataSent` and calling `pushChannelsSampleRateInfo` and `pushCodecInfo` once, then mark `_metadataSent` true.
- Add unit test `testStandardMetadataIsPopulated` to `test_audioloader_streaming.py` to verify metadata outputs are present and sane for a sample WAV file.

### Testing
- Ran the `test/src/unittests/io/test_audioloader_streaming.py` unit tests including the new `testStandardMetadataIsPopulated` and existing audio loader streaming tests, and they passed.
- The new metadata population test validated non-empty `audio`, positive `sampleRate`, positive `numberChannels`, non-empty `codec`, and non-negative `bit_rate` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a5a44b3083329da06280e7c011ed)