### PR TITLE
Add MSYS2/MinGW-w64 native Windows build docs and CI workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,6 +4,7 @@ Active workflows:
 
 - `build-wheels-cibuildwheel.yml`: wheel builds for Linux/macOS/Windows.
 - `build-docs.yml`: documentation build validation.
+- `build-windows-msys2.yml`: native Windows C++ build validation using MSYS2/MinGW-w64.
 
 Removed workflows:
 

--- a/.github/workflows/build-windows-msys2.yml
+++ b/.github/workflows/build-windows-msys2.yml
@@ -1,0 +1,41 @@
+name: build-windows-msys2
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  mingw-msys2-build:
+    name: MSYS2 MinGW-w64 build
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-fftw
+            mingw-w64-x86_64-taglib
+            mingw-w64-x86_64-libsndfile
+            mingw-w64-x86_64-yaml-cpp
+
+      - name: Configure (MinGW)
+        shell: msys2 {0}
+        run: |
+          python waf configure --with-static-examples
+
+      - name: Build (MinGW)
+        shell: msys2 {0}
+        run: |
+          python waf -v

--- a/doc/sphinxdoc/installing.rst
+++ b/doc/sphinxdoc/installing.rst
@@ -208,6 +208,33 @@ Building Essentia on Windows
 
 Essentia C++ library and extractors based on it can be compiled and run correctly on Windows, but Python bindings are not supported yet. The easiest way to build Essentia is by `cross-compilation on Linux using MinGW <FAQ.html#cross-compiling-for-windows-on-linux>`_. However the resulting library binaries are only compatible within C++ projects using MinGW compilers, and therefore they are not compatible with Visual Studio. If you want to use Visual Studio, there is no project readily available, so you will have to setup one yourself and compile the dependencies too.
 
+Building Essentia natively with MSYS2/MinGW-w64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also build Essentia directly on Windows using an MSYS2 MinGW shell.
+
+1. Install `MSYS2 <https://www.msys2.org/>`_ and open the **MSYS2 MinGW 64-bit** shell.
+2. Update the base system and MinGW packages::
+
+     pacman -Syu
+     pacman -Su
+     pacman -S --needed base-devel mingw-w64-x86_64-toolchain \
+       mingw-w64-x86_64-pkgconf mingw-w64-x86_64-fftw \
+       mingw-w64-x86_64-taglib mingw-w64-x86_64-libsndfile \
+       mingw-w64-x86_64-yaml-cpp
+
+3. From the Essentia source tree, configure and build::
+
+     ./waf configure --with-static-examples --with-vamp
+     ./waf
+
+4. (Optional) install into the MinGW prefix::
+
+     ./waf install
+
+If ``pkg-config`` fails to locate a dependency, verify that you are running in a MinGW shell and that ``/mingw64/bin`` is in your ``PATH``.
+In this repository, the same native Windows path is validated in CI by ``.github/workflows/build-windows-msys2.yml``.
+
 Building Essentia in Windows Subsystem for Linux (WSL)
 ------------------------------------------------------
 It is possible to install Essentia easily in the *Windows Subsystem for Linux* on Windows 10. This environment allows to run the same command-line utilities that could be run within your favorite `distribution <https://aka.ms/wslstore>`_. Note that WSL is still in its infancy and the methods of interoperability between Windows applications and WSL are likely to change in the future.


### PR DESCRIPTION
### Motivation

- Enable and validate native Windows builds using MSYS2/MinGW-w64 and provide clear developer instructions. 
- Make CI coverage explicit for native MinGW builds so regressions on Windows are detected early. 
- Surface the new workflow in the workflows README so contributors know about Windows validation.

### Description

- Add `.github/workflows/build-windows-msys2.yml` which sets up an MSYS2 MinGW64 environment, installs required packages, and runs `python waf configure --with-static-examples` and `python waf -v` inside an MSYS2 shell. 
- Update `doc/sphinxdoc/installing.rst` with a new "Building Essentia natively with MSYS2/MinGW-w64" section that documents `pacman` package installs and `./waf configure`/`./waf` build steps and notes about `pkg-config` and PATH. 
- Update `.github/workflows/README.md` to list the new `build-windows-msys2.yml` workflow among active workflows.

### Testing

- No automated CI jobs were executed as part of this change. 
- The new GitHub Actions workflow is configured to run on `pull_request` and `push` to `master` and will perform package provisioning and a configure/build step when triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8d2eeab208332bfa6af7d58c0fa19)